### PR TITLE
Fix token status UI update

### DIFF
--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -297,10 +297,10 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                             <SiSpotify className="h-3 w-3 text-emerald-600" />
                             <span>
                               {spotifyProfile?.subscription_type || 'Spotify'} • 
-                              {spotifyProfile?.connection_status === 'active' ? ' Connected' : 
-                               spotifyProfile?.connection_status === 'expired' ? ' Token Expired' :
-                               spotifyProfile?.connection_status === 'invalid' ? ' Connection Invalid' :
-                               ' Verified'}
+                                {spotifyProfile?.connection_status === 'active' ? ' Running' :
+                                 spotifyProfile?.connection_status === 'expired' || spotifyProfile?.connection_status === 'token_expired' ? ' Token Expired' :
+                                 spotifyProfile?.connection_status === 'invalid' ? ' Connection Invalid' :
+                                 ' Verified'}
                             </span>
                           </span>
                         ) : (


### PR DESCRIPTION
## Summary
- ensure token status is refreshed after verification
- add fallback fetch of profile when refresh endpoint doesn't return it
- handle `token_expired` status consistently and show `Running` when active

## Testing
- `npm run type-check` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864f2d57248833280b22dff03ea955b